### PR TITLE
Bugfix/fix index handle typo

### DIFF
--- a/internals/scaffold/tasks/constants.js
+++ b/internals/scaffold/tasks/constants.js
@@ -83,7 +83,7 @@ const codePipelineProjectName = projectName;
 /**
  * CodePipeline project ARN.
  */
-const codePipelineProjectArn = `arn:aws:kms:${process.env.AWS_REGION}:${process.env.AWS_ACCOUNT_ID}:${codePipelineProjectName}`;
+const codePipelineProjectArn = `arn:aws:codepipeline:${process.env.AWS_REGION}:${process.env.AWS_ACCOUNT_ID}:${codePipelineProjectName}`;
 
 /**
  * The name of the role assumed by CodePipeline when building the project.

--- a/internals/scaffold/tasks/create_codebuild.js
+++ b/internals/scaffold/tasks/create_codebuild.js
@@ -83,7 +83,7 @@ const task = (() =>
                 },
                 {
                   Effect: 'Allow',
-                  Resource: `arn:aws:s3:::${constants.artifactBucketName}`,
+                  Resource: `arn:aws:s3:::${constants.artifactBucketName}/*`,
                   Action: [
                     's3:PutObject',
                     's3:GetObject',

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import awsServerlessExpress from 'aws-serverless-express';
 import app from './app';
 
 const server = awsServerlessExpress.createServer(app);
-exports.handler = (event, context) => {
+exports.handle = (event, context) => {
   // HACK to make winston works!
   delete console._stdout;
   delete console._stderr;


### PR DESCRIPTION
Fix the following issues:
#7 - Change `handle` instead of `handler` to align of Lambda settings.
#6 - CloudWatch permission to `codepipeline` instead of `kms` (copy-paste typo)
#3 - Forgot to include wildcards when scaffolding CodeBuild permission